### PR TITLE
Fixes to async web services calls to improve error handling and debugging experience.

### DIFF
--- a/Src/Buddy.cs
+++ b/Src/Buddy.cs
@@ -60,31 +60,42 @@ namespace BuddySDK
             }
         }
 
-        public static Task<BuddyResult<T>> GetAsync<T>(string path, object parameters = null)
+        public static async Task<BuddyResult<T>> GetAsync<T>(string path, object parameters = null)
         {
-            return CurrentInstance.GetAsync<T>(path, parameters);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.GetAsync<T>(path, parameters).ConfigureAwait(false);
         }
-        public static Task<BuddyResult<T>> PostAsync<T>(string path, object parameters = null)
+        public static async Task<BuddyResult<T>> PostAsync<T>(string path, object parameters = null)
         {
-            return CurrentInstance.PostAsync<T>(path, parameters);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.PostAsync<T>(path, parameters).ConfigureAwait(false);
         }
-        public static Task<BuddyResult<T>> PutAsync<T>(string path, object parameters = null)
+        public static async Task<BuddyResult<T>> PutAsync<T>(string path, object parameters = null)
         {
-            return CurrentInstance.PutAsync<T>(path, parameters);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.PutAsync<T>(path, parameters).ConfigureAwait(false);
         }
-        public static Task<BuddyResult<T>> PatchAsync<T>(string path, object parameters = null)
+        public static async Task<BuddyResult<T>> PatchAsync<T>(string path, object parameters = null)
         {
-            return CurrentInstance.PatchAsync<T>(path, parameters);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.PatchAsync<T>(path, parameters).ConfigureAwait(false);
         }
-        public static Task<BuddyResult<T>> DeleteAsync<T>(string path, object parameters = null)
+        public static async Task<BuddyResult<T>> DeleteAsync<T>(string path, object parameters = null)
         {
-            return CurrentInstance.DeleteAsync<T>(path, parameters);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.DeleteAsync<T>(path, parameters).ConfigureAwait(false);
         }
-       
-        public static Task<User> GetCurrentUserAsync (bool reload = false)
+
+        public static async Task<User> GetCurrentUserAsync(bool reload = false)
         {
-           
-            return CurrentInstance.GetCurrentUserAsync (reload);
+            // Do await even in this trivial case 
+            // for this method to appear in debugger's call stack.
+            return await CurrentInstance.GetCurrentUserAsync(reload).ConfigureAwait(false);
         }
 
         public static void RunOnUiThread(Action a) {

--- a/Src/BuddyClient.cs
+++ b/Src/BuddyClient.cs
@@ -1086,48 +1086,43 @@ namespace BuddySDK
 
         #region REST
 
-        //TODO Much awesome refactoring and testing
-        private Task<BuddyResult<T>> GenericRestCall<T>(string verb, string path, object parameters, bool allowThrow, TaskCompletionSource<BuddyResult<T>> promise)
+        private async Task<BuddyResult<T>> GenericRestCall<T>(string verb, string path, object parameters, bool allowThrow)
         {
-            GetService()
-                .ContinueWith(service =>
-                     service.Result.CallMethodAsync<T>(verb, path, AddLocationToParameters(parameters))
-                        .ContinueWith(callResult => {
-                            HandleServiceResult(callResult.Result, allowThrow)
-                                 .ContinueWith(procResult =>
-                                 {
-                                     if (procResult.IsFaulted)
-                                     {
-                                         promise.SetException(procResult.Exception);
-                                     }
-                                     else
-                                     {
-                                         promise.SetResult(procResult.Result);
-                                     }
-                                 });
-                         })
-                ).ConfigureAwait(false);
-            return promise.Task;
+            var service = await GetService().ConfigureAwait(false);
+
+            var callResult = await service.CallMethodAsync<T>(
+                verb,
+                path,
+                AddLocationToParameters(parameters)).ConfigureAwait(false);
+
+            var procResult = await HandleServiceResult(callResult, allowThrow).ConfigureAwait(false);
+
+            return procResult;
         }
 
-        public  Task<BuddyResult<T>> GetAsync<T>(string path, object parameters = null){
-            return GenericRestCall(GetVerb, path, parameters, false, new TaskCompletionSource<BuddyResult<T>>());
+        public Task<BuddyResult<T>> GetAsync<T>(string path, object parameters = null)
+        {
+            return GenericRestCall<T>(GetVerb, path, parameters, false);
         }
 
-        public Task<BuddyResult<T>> PostAsync<T>(string path, object parameters = null){
-            return GenericRestCall(PostVerb, path, parameters, false, new TaskCompletionSource<BuddyResult<T>>());
+        public Task<BuddyResult<T>> PostAsync<T>(string path, object parameters = null)
+        {
+            return GenericRestCall<T>(PostVerb, path, parameters, false);
         }
 
-        public Task<BuddyResult<T>> PatchAsync<T>(string path, object parameters = null){
-            return GenericRestCall(PatchVerb, path, parameters, false, new TaskCompletionSource<BuddyResult<T>>());
+        public Task<BuddyResult<T>> PatchAsync<T>(string path, object parameters = null)
+        {
+            return GenericRestCall<T>(PatchVerb, path, parameters, false);
         }
 
-        public Task<BuddyResult<T>> PutAsync<T>(string path, object parameters = null){
-            return GenericRestCall(PutVerb, path, parameters, false, new TaskCompletionSource<BuddyResult<T>>());
+        public Task<BuddyResult<T>> PutAsync<T>(string path, object parameters = null)
+        {
+            return GenericRestCall<T>(PutVerb, path, parameters, false);
         }
 
-        public Task<BuddyResult<T>> DeleteAsync<T>(string path, object parameters = null){
-            return GenericRestCall(DeleteVerb, path, parameters, false, new TaskCompletionSource<BuddyResult<T>>());
+        public Task<BuddyResult<T>> DeleteAsync<T>(string path, object parameters = null)
+        {
+            return GenericRestCall<T>(DeleteVerb, path, parameters, false);
         }
         #endregion
     }

--- a/Src/BuddyServiceClient/BuddyServiceClientBase.cs
+++ b/Src/BuddyServiceClient/BuddyServiceClientBase.cs
@@ -128,23 +128,15 @@ namespace BuddySDK.BuddyServiceClient
             PlatformAccess.Current.InvokeOnUiThread(callback);
         }
 
-        public Task<BuddyCallResult<T>> CallMethodAsync<T>(string verb, string path, object parameters = null)
-        {   
-            var tcs = new TaskCompletionSource<BuddyCallResult<T>>();
-
-
-
-            CallMethodAsync<T>(verb, path, parameters, (bcr) =>
-            {
-
-                tcs.TrySetResult(bcr);
-
-
-            });
-            return tcs.Task;
+        public async Task<BuddyCallResult<T>> CallMethodAsync<T>(
+           string verb,
+           string path,
+           object parameters = null)
+        {
+            return await CallMethodAsyncCore<T>(verb, path, parameters).ConfigureAwait(false);
         }
 
-        protected abstract void CallMethodAsync<T>(string verb, string path, object parameters, Action<BuddyCallResult<T>> callback);
+        protected abstract Task<BuddyCallResult<T>> CallMethodAsyncCore<T>(string verb, string path, object parameters);
 
         private string serviceRoot;
         public string ServiceRoot


### PR DESCRIPTION
This PR is related to my work in BuddySource with refactoring MongoDB code to use async methods. That goes far beyond MongoDB, and reaches tests and services, and these are being refactored to be async too. Therefore, many tests which call services use the client from this SDK, and this client has some extensibility points which play not ideally in some scenarios with asyncs in tests: sometimes errors are not propagated, sometimes tests hang, sometimes both. Also, due to use of direct tasks returning and ContinueWith, debugger is not able to show the full call stack, which valuably complicates finding error source (I will probably write a separate email explaining this story). This PR introduces minor (though possibly incompatible) code changes which improves situation to some degree (more precisely, it provides better base for tests client to implement its errors reporting, see here how: https://github.com/andriysavin/BuddySource/commit/95a359d0f703cc233974afcd023336f96b0c23ba). Possibly, further refactoring should be done later.

This PR was created separately because this is a separate repository, and I'm not able to modify its files from the repository/branch I work in with Mongo refactoring.